### PR TITLE
Configuration modified to work with certbot installed in host

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -28,6 +28,6 @@ services:
       - ./static:/var/www/web/
       - /etc/letsencrypt:/etc/letsencrypt
       - /var/www/certbot:/var/www/certbot/
-    #command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+    command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     depends_on:
       - flask

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - ./nginx:/etc/nginx/conf.d
       - ./static:/var/www/web/
       - /etc/letsencrypt:/etc/letsencrypt
+      - /var/www/certbot:/var/www/certbot/
     #command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     depends_on:
       - flask

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,12 +20,13 @@ services:
     image: nginx:1.14.2-alpine
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - "80:80"
       - "443:443"
     volumes:
       - ./nginx/certs:/etc/nginx/certs
       - ./nginx:/etc/nginx/conf.d
       - ./static:/var/www/web/
+      - /etc/letsencrypt:/etc/letsencrypt
     #command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     depends_on:
       - flask

--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -5,8 +5,16 @@ root /var/www/web;
 server {
   listen       80 default_server;
   listen       [::]:80 default_server;
+  
   server_name _;
-  return 301 https://$host$request_uri;
+
+  location /.well-known/acme-challenge/ {
+    root /var/www/certbot;
+  }
+
+  location / {
+    return 301 https://$host$request_uri;
+  }
 }
 
 server {

--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -3,13 +3,19 @@ gzip on;
 root /var/www/web;
 
 server {
+  listen       80 default_server;
+  listen       [::]:80 default_server;
+  server_name _;
+  return 301 https://$host$request_uri;
+}
+
+server {
   listen       443 http2 ssl;
   listen       [::]:443 http2 ssl;
   ssl_certificate /etc/nginx/certs/certificate.crt;
   ssl_certificate_key /etc/nginx/certs/private_key.key;
 
-  listen       80 default_server;
-  listen       [::]:80 default_server;
+  server_name perf.test.fedcloud.eu;
 
   location / {
     autoindex off;
@@ -28,4 +34,3 @@ server {
 
   #error_page 404 /404.html;
 }
-


### PR DESCRIPTION
This should close #50 
However, the volume link to "/etc/letsencrypt:/etc/letsencrypt" is not very elegant, there should be a better way but for now it works.

Also "server_name perf.test.fedcloud.eu;" should not provide the direct dns name (although probably can be removed)

Therefore is not ready to close, but to keep as branch for now.